### PR TITLE
add __dirname also in the windows-x64 version

### DIFF
--- a/packages/windows-x64/src/index.ts
+++ b/packages/windows-x64/src/index.ts
@@ -1,5 +1,7 @@
 import path from 'path';
-
+import { fileURLToPath } from 'url';
+    
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const pg_ctl = path.resolve(__dirname, '..', 'native', 'bin', 'pg_ctl.exe');
 export const initdb = path.resolve(__dirname, '..', 'native', 'bin', 'initdb.exe');
 export const postgres = path.resolve(__dirname, '..', 'native', 'bin', 'postgres.exe');


### PR DESCRIPTION
This is needed to make it work on windows.
If not this is the error thrown at runtime:

```
(node:7164) UnhandledPromiseRejectionWarning: ReferenceError: __dirname is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and 'C:\Users\miggianox\Desktop\p1\desktop\node_modules\@embedded-postgres\windows-x64\package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
  at file:///C:/Users/miggianox/Desktop/p1/desktop/node_modules/@embedded-postgres/windows-x64/dist/index.js:2:36
  at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
  at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
```