### PR TITLE
fix: explicitly specify LC_MESSAGES locale initialise completes on non-english systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -22,6 +22,13 @@ jobs:
       - run: npm run lint
       - run: npm run download
       - name: Run test
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd packages/embedded-postgres
+          npm test
+      - name: Run test (NL locale)
+        env:
+          LC_ALL: nl_NL.utf8
         if: matrix.os != 'windows-latest'
         run: |
           cd packages/embedded-postgres

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "lerna run start --parallel",
     "build": "lerna run build",
     "download": "lerna run download --parallel",
-    "download-all": "lerna run download --parallel -- --all",
+    "download-all": "lerna run download --parallel -- -- --all",
     "docs": "lerna run docs --parallel",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "test": "lerna run test"

--- a/packages/darwin-arm64/scripts/download.js
+++ b/packages/darwin-arm64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/darwin-x64/scripts/download.js
+++ b/packages/darwin-x64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/embedded-postgres/src/index.ts
+++ b/packages/embedded-postgres/src/index.ts
@@ -14,6 +14,14 @@ const bin = getBinaries();
 const { Client } = pg;
 
 /**
+ * We have to specify the LC_MESSAGES locale because we rely on inspecting the
+ * output of the `initdb` command to see if Postgres is ready. As we're looking
+ * for a particular string, we need to force that string into the right locale.
+ * @see https://github.com/leinelissen/embedded-postgres/issues/15
+ */
+const LC_MESSAGES_LOCALE = 'en_US.UTF-8';
+
+/**
  * Previosuly, options were specified in snake_case rather than camelCase. Old
  * options are still translated to new variants.
  */
@@ -136,6 +144,7 @@ class EmbeddedPostgres {
                 `--auth=${this.options.authMethod}`,
                 `--username=${this.options.user}`,
                 `--pwfile=${passwordFile}`,
+                `--lc-messages=${LC_MESSAGES_LOCALE}`,
                 ...this.options.initdbFlags,
             ], { stdio: 'inherit', ...permissionIds,  });
 
@@ -177,7 +186,7 @@ class EmbeddedPostgres {
                 '-p',
                 this.options.port.toString(),
                 ...this.options.postgresFlags,
-            ], { ...permissionIds });
+            ], { ...permissionIds, env: { LC_MESSAGES: LC_MESSAGES_LOCALE } });
 
             // Connect to stderr, as that is where the messages get sent
             this.process.stderr?.on('data', (chunk: Buffer) => {

--- a/packages/embedded-postgres/src/index.ts
+++ b/packages/embedded-postgres/src/index.ts
@@ -146,7 +146,14 @@ class EmbeddedPostgres {
                 `--pwfile=${passwordFile}`,
                 `--lc-messages=${LC_MESSAGES_LOCALE}`,
                 ...this.options.initdbFlags,
-            ], { stdio: 'inherit', ...permissionIds,  });
+            ], { ...permissionIds, env: { LC_MESSAGES: LC_MESSAGES_LOCALE } });
+
+            // Connect to stderr, as that is where the messages get sent
+            process.stdout?.on('data', (chunk: Buffer) => {
+                // Parse the data as a string and log it
+                const message = chunk.toString('utf-8');
+                this.options.onLog(message); 
+            });
 
             process.on('exit', (code) => {
                 if (code === 0) {

--- a/packages/embedded-postgres/tests/index.test.ts
+++ b/packages/embedded-postgres/tests/index.test.ts
@@ -27,7 +27,7 @@ afterEach(async () => {
     await pg?.stop();
     
     // Remove all cluster files
-    await fs.rm(path.join(DB_PATH), { recursive: true, force: true });
+    // await fs.rm(path.join(DB_PATH), { recursive: true, force: true });
 });
 
 it('should be able to initialise a cluster', async () => {

--- a/packages/embedded-postgres/tests/index.test.ts
+++ b/packages/embedded-postgres/tests/index.test.ts
@@ -27,7 +27,7 @@ afterEach(async () => {
     await pg?.stop();
     
     // Remove all cluster files
-    // await fs.rm(path.join(DB_PATH), { recursive: true, force: true });
+    await fs.rm(path.join(DB_PATH), { recursive: true, force: true });
 });
 
 it('should be able to initialise a cluster', async () => {

--- a/packages/linux-arm/scripts/download.js
+++ b/packages/linux-arm/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/linux-arm64/scripts/download.js
+++ b/packages/linux-arm64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/linux-ia32/scripts/download.js
+++ b/packages/linux-ia32/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/linux-ppc64/scripts/download.js
+++ b/packages/linux-ppc64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/linux-x64/scripts/download.js
+++ b/packages/linux-x64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);

--- a/packages/windows-x64/scripts/download.js
+++ b/packages/windows-x64/scripts/download.js
@@ -1,5 +1,4 @@
 import { downloadBinaries } from '@embedded-postgres/downloader';
 import { readSymlinks } from '@embedded-postgres/symlink-reader';
 import packageJson from '../package.json' with { type: "json" };
-const { version, cpu, os } = packageJson;
-downloadBinaries(process.argv[2] || version, cpu, os).then(readSymlinks);
+downloadBinaries(process.argv, packageJson).then(readSymlinks);


### PR DESCRIPTION
We have to specify the LC_MESSAGES locale because we rely on inspecting the output of the `initdb` command to see if Postgres is ready. As we're looking for a particular string, we need to force that string into the right locale.

Fixes #15 