### PR TITLE
Fix repository typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ development, you might need some extra pointers
 
 ### Development
 In order to get yourself situated for development, you will need to the
-reopistory up and running. In order to make this work, start with a relatively
+repository up and running. In order to make this work, start with a relatively
 recent install of NodeJS (at least v18, v20+ recommended). You can then run this
 command to install all packages:
 ```

--- a/packages/embedded-postgres/README.md
+++ b/packages/embedded-postgres/README.md
@@ -125,7 +125,7 @@ development, you might need some extra pointers
 
 ### Development
 In order to get yourself situated for development, you will need to the
-reopistory up and running. In order to make this work, start with a relatively
+repository up and running. In order to make this work, start with a relatively
 recent install of NodeJS (at least v18, v20+ recommended). You can then run this
 command to install all packages:
 ```


### PR DESCRIPTION
## Summary
- fix `reopistory` typo in README and packages README

## Testing
- `npm test` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878b96d784c8330abb05a3c8ca05d9c