### PR TITLE
fix: hydrate symlinks at runtime when postinstall is skipped

### DIFF
--- a/packages/embedded-postgres/src/binary.ts
+++ b/packages/embedded-postgres/src/binary.ts
@@ -1,4 +1,6 @@
 import os from 'os';
+import fs from 'fs/promises';
+import path from 'path';
 
 export type PostgresBinaries = {
     postgres: string;
@@ -6,45 +8,113 @@ export type PostgresBinaries = {
     initdb: string;
 }
 
-function getBinaries(): Promise<PostgresBinaries> {
+/**
+ * npm does not preserve symlinks when publishing packages. The platform
+ * packages include a `pg-symlinks.json` file that records the original
+ * symlinks, and a `postinstall` script (`hydrate-symlinks.js`) to restore
+ * them. However, some package managers and tools (e.g. bunx, pnpm with
+ * --ignore-scripts, yarn PnP) skip lifecycle scripts, so the symlinks may
+ * never be restored.
+ *
+ * This function ensures symlinks are hydrated at runtime if they are missing,
+ * so the postgres binaries work regardless of how the package was installed.
+ */
+async function hydrateSymlinksIfNeeded(binPath: string): Promise<void> {
+    // Resolve the native directory from the binary path (bin -> native -> pg-symlinks.json)
+    const nativeDir = path.dirname(path.dirname(binPath));
+    const symlinkFile = path.join(nativeDir, 'pg-symlinks.json');
+
+    // Read the symlinks manifest
+    let symlinks: { source: string; target: string }[];
+    try {
+        const content = await fs.readFile(symlinkFile, { encoding: 'utf-8' });
+        symlinks = JSON.parse(content);
+    } catch {
+        // No symlinks file found — nothing to do
+        return;
+    }
+
+    // The paths in pg-symlinks.json are relative to the package root (parent of native/)
+    const packageRoot = path.dirname(nativeDir);
+
+    for (const { source, target } of symlinks) {
+        const absoluteTarget = path.resolve(packageRoot, target);
+
+        // Only create symlinks that don't already exist
+        try {
+            await fs.lstat(absoluteTarget);
+        } catch {
+            // Target doesn't exist — create the symlink
+            const absoluteSource = path.resolve(packageRoot, source);
+            const dirname = path.dirname(absoluteTarget);
+            const relSource = path.relative(dirname, absoluteSource);
+
+            try {
+                await fs.symlink(relSource, absoluteTarget);
+            } catch {
+                // Swallow errors (e.g. read-only filesystem, race conditions)
+            }
+        }
+    }
+}
+
+async function getBinaries(): Promise<PostgresBinaries> {
     const arch = os.arch();
     const platform = os.platform();
-    
+
+    let binaries: PostgresBinaries;
+
     switch (platform) {
         case 'darwin':
             switch(arch) {
                 case 'arm64':
-                    return import('@embedded-postgres/darwin-arm64');
+                    binaries = await import('@embedded-postgres/darwin-arm64');
+                    break;
                 case 'x64':
-                    return import('@embedded-postgres/darwin-x64');
+                    binaries = await import('@embedded-postgres/darwin-x64');
+                    break;
                 default:
                     throw new Error(`Unsupported arch "${arch}" for platform "${platform}"`);
             }
+            break;
         case 'linux':
             switch(arch) {
                 case 'arm64':
-                    return import('@embedded-postgres/linux-arm64');
+                    binaries = await import('@embedded-postgres/linux-arm64');
+                    break;
                 case 'arm':
-                    return import('@embedded-postgres/linux-arm');
+                    binaries = await import('@embedded-postgres/linux-arm');
+                    break;
                 case 'ia32':
-                    return import('@embedded-postgres/linux-ia32');
+                    binaries = await import('@embedded-postgres/linux-ia32');
+                    break;
                 case 'ppc64':
-                    return import('@embedded-postgres/linux-ppc64');
+                    binaries = await import('@embedded-postgres/linux-ppc64');
+                    break;
                 case 'x64':
-                    return import('@embedded-postgres/linux-x64');
-                default:
-                    throw new Error(`Unsupported arch "${arch}" for platform "${platform}"`);    
-            }
-        case 'win32':
-            switch(arch) {
-                case 'x64':
-                    return import('@embedded-postgres/windows-x64');
+                    binaries = await import('@embedded-postgres/linux-x64');
+                    break;
                 default:
                     throw new Error(`Unsupported arch "${arch}" for platform "${platform}"`);
             }
+            break;
+        case 'win32':
+            switch(arch) {
+                case 'x64':
+                    binaries = await import('@embedded-postgres/windows-x64');
+                    break;
+                default:
+                    throw new Error(`Unsupported arch "${arch}" for platform "${platform}"`);
+            }
+            break;
         default:
             throw new Error(`Unsupported platform "${platform}"`);
     }
+
+    // Ensure symlinks are hydrated before returning binary paths
+    await hydrateSymlinksIfNeeded(binaries.postgres);
+
+    return binaries;
 }
 
 export default getBinaries;


### PR DESCRIPTION
## Problem

npm does not preserve symlinks when publishing packages. The platform packages (e.g. `@embedded-postgres/darwin-arm64`) ship a `pg-symlinks.json` manifest and a `postinstall` script (`hydrate-symlinks.js`) to restore symlinks after installation.

However, several common tools and configurations **skip lifecycle scripts**, leaving the dylib/so symlinks missing:

- **`bunx`** — always skips postinstall
- **`pnpm`** with `--ignore-scripts`  
- **`yarn` PnP** — doesn't run postinstall in certain configurations
- **`npm`** with `--ignore-scripts`

Without these symlinks, the postgres binaries crash at startup with errors like:

```
dyld: Library not loaded: @loader_path/../lib/libzstd.1.dylib
  Reason: no such file
```

This is the same class of issue as #21 (Linux shared libraries), but affecting **all platforms** where symlinks exist in the native directory.

## Solution

Add runtime symlink hydration in `getBinaries()` (`packages/embedded-postgres/src/binary.ts`). After importing the platform package, it:

1. Locates `pg-symlinks.json` relative to the binary path
2. Checks each symlink target with `lstat`
3. Creates only missing symlinks using relative paths (matching the existing `hydrate-symlinks.js` behavior)

The check is:
- **Idempotent** — skips already-existing symlinks
- **Safe on read-only filesystems** — silently swallows errors
- **Zero overhead when symlinks exist** — just a series of `lstat` calls that hit the fs cache

The existing `postinstall` script is kept as-is for the fast path when lifecycle scripts do run.

## Test plan

- Verified on macOS darwin-arm64 with `bunx paperclipai@latest` (which uses `embedded-postgres` internally)
- Before fix: `initdb` and `postgres` crash with dyld missing library errors
- After fix: all 30+ symlinks from `pg-symlinks.json` are hydrated and postgres starts successfully"
<parameter name="maintainer_can_modify">true